### PR TITLE
Create sudoers.d as a directory instead of a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ config_dir_ensure
 -----------------
 Ensure attribute of $config_dir
 
-- *Default*: 'present'
+- *Default*: 'directory'
 
 config_dir_purge
 ----------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class sudo (
   $config_dir        = '/etc/sudoers.d',
   $config_dir_group  = 'root',
   $config_dir_mode   = '0750',
-  $config_dir_ensure = 'present',
+  $config_dir_ensure = 'directory',
   $config_dir_purge  = 'true',
   $sudoers           = undef,
   $sudoers_manage    = 'true',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,7 +7,7 @@ describe 'sudo' do
         'name'   => 'sudo',
       })
       should contain_file('/etc/sudoers.d').with({
-        'ensure'  => 'present',
+        'ensure'  => 'directory',
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0750',
@@ -83,7 +83,7 @@ describe 'sudo' do
     let(:params) { {:package_manage  => 'false' } }
     it do
       should contain_file('/etc/sudoers.d').with({
-        'ensure'  => 'present',
+        'ensure'  => 'directory',
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0750',


### PR DESCRIPTION
Before this commit /etc/sudoers.d was created as a file instead of a
directory if parameter sudoers was undefined. This prevents the module
from properly storing sudo rules in /etc/sudoers.d later when parameter
sudoers is defined.
