### PR TITLE
add support to verify sudoers

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -34,9 +34,9 @@ define sudo::fragment (
   }
 
 
-  exec {"verify_sudoers_${name}":
-    path    => '/usr/bin:/usr/sbin:/bin',
+  exec { "verify_sudoers_${name}":
     command => "rm -f ${tmp_config_dir}/puppet_verify_sudo_merged; false",
+    path    => '/usr/bin:/usr/sbin:/bin',
     unless  => "visudo -f ${tmp_config_dir}/puppet_verify_sudo_merged -c",
     require => Exec["delete_tmp_sudoers_${name}"],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,7 +152,6 @@ class sudo (
         group   => $config_dir_group,
         mode    => '0440',
         content => '',
-        #        require => Exec['remove_merge_file']
       }
 
       Sudo::Fragment <| |> -> Exec <|title == 'remove_merge_file'|>


### PR DESCRIPTION
Hello, this module now merges all the sudoers entries specified in hiera in /tmp, runs "visudo -f <path_to_merge_file> -c" and  then if all is good pushes the new sudoers out to /etc/sudoers.d/

Spec tests went well so nothing was destoyed.. (famous last words), but writing new spec tests for my change might be a bit tricky.
