### PR TITLE
Remove support for verifying sudoers fragment

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -6,40 +6,8 @@ define sudo::fragment (
   $content          = undef,
   $source           = undef,
   $config_dir       = $sudo::config_dir,
-  $tmp_config_dir   = $sudo::tmp_config_dir,
   $config_dir_group = $sudo::config_dir_group,
 ) {
-
-  file { "tmp_sudoers_file_${name}":
-    ensure  => $ensure,
-    path    => "${tmp_config_dir}/puppet_verify_sudo_${name}",
-    owner   => 'root',
-    group   => $config_dir_group,
-    mode    => '0440',
-    source  => $source,
-    content => $content,
-    require => File['create_merge_file']
-  }
-
-  exec { "merge_all_sudoers_${name}":
-    command => "cat ${tmp_config_dir}/puppet_verify_sudo_${name} >> ${tmp_config_dir}/puppet_verify_sudo_merged",
-    path    => '/usr/bin:/usr/sbin:/bin',
-    require => File["tmp_sudoers_file_${name}"],
-  }
-
-  exec { "delete_tmp_sudoers_${name}":
-    command => "rm -f ${tmp_config_dir}/puppet_verify_sudo_${name}",
-    path    => '/usr/bin:/usr/sbin:/bin',
-    require => Exec["merge_all_sudoers_${name}"]
-  }
-
-
-  exec { "verify_sudoers_${name}":
-    command => "rm -f ${tmp_config_dir}/puppet_verify_sudo_merged; false",
-    path    => '/usr/bin:/usr/sbin:/bin',
-    unless  => "visudo -f ${tmp_config_dir}/puppet_verify_sudo_merged -c",
-    require => Exec["delete_tmp_sudoers_${name}"],
-  }
 
   file { "${priority}_${name}":
     ensure  => $ensure,
@@ -49,7 +17,6 @@ define sudo::fragment (
     mode    => '0440',
     source  => $source,
     content => $content,
-    require => Exec["verify_sudoers_${name}"],
   }
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,6 @@ class sudo (
   $config_dir_purge     = 'true',
   $sudoers              = undef,
   $sudoers_manage       = 'true',
-  $tmp_config_dir       = '/tmp',
   $config_file          = '/etc/sudoers',
   $config_file_group    = 'root',
   $config_file_owner    = 'root',
@@ -145,22 +144,7 @@ class sudo (
     # Only works with sudo >= 1.7.2
     if $sudoers != undef {
       validate_hash($sudoers)
-      file { 'create_merge_file':
-        ensure  => 'present',
-        path    => "${tmp_config_dir}/puppet_verify_sudo_merged",
-        owner   => 'root',
-        group   => $config_dir_group,
-        mode    => '0440',
-        content => '',
-      }
-
-      Sudo::Fragment <| |> -> Exec <|title == 'remove_merge_file'|>
       create_resources('sudo::fragment',$sudoers)
-      exec { 'remove_merge_file':
-        command => "rm ${tmp_config_dir}/puppet_verify_sudo_merged",
-        path    => '/usr/bin:/usr/sbin:/bin',
-        onlyif  => "test -f ${tmp_config_dir}/puppet_verify_sudo_merged",
-      }
     }
   }
 }


### PR DESCRIPTION
The functionality caused nodes to report status changed on every run.
Issue #13.
